### PR TITLE
Add permission recommendation URLs

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -20,6 +20,10 @@ type Handlers struct {
 	Demo    bool
 }
 
+type CreateEventBatchResponse struct {
+	AlertIDs []string `json:"alertIDs"`
+}
+
 // CreateEventBatch creates a batch of events
 func (h *Handlers) CreateEventBatch(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -34,6 +38,7 @@ func (h *Handlers) CreateEventBatch(w http.ResponseWriter, r *http.Request) {
 
 	advisor := recommendations.NewAdvisor()
 
+	var res CreateEventBatchResponse
 	for _, e := range rec {
 		// censor info if in demo mode
 		if h.Demo {
@@ -57,6 +62,8 @@ func (h *Handlers) CreateEventBatch(w http.ResponseWriter, r *http.Request) {
 			HasRecommendations: false,
 		}
 
+		res.AlertIDs = append(res.AlertIDs, alert.ID)
+
 		if len(advice) > 0 {
 			alert.HasRecommendations = true
 			alert.Recommendations = advice
@@ -66,5 +73,5 @@ func (h *Handlers) CreateEventBatch(w http.ResponseWriter, r *http.Request) {
 		h.Storage.Add(alert)
 	}
 
-	w.WriteHeader(http.StatusAccepted)
+	io.RespondJSON(ctx, h.Log, w, res, http.StatusAccepted)
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,11 @@
 import { ChakraProvider, Container } from "@chakra-ui/react";
 import React from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Redirect,
+  Route,
+  Switch,
+} from "react-router-dom";
 import { SWRConfig } from "swr";
 import { fetchWithAuth } from "./api";
 import { AuthProvider } from "./context/authContext";
@@ -14,6 +19,12 @@ function App() {
         <Container maxW="1200px" py={5}>
           <Switch>
             <Route path="/" exact>
+              <Redirect to="/alerts" />
+            </Route>
+            <Route path="/alerts" exact>
+              <Alerts />
+            </Route>
+            <Route path="/alerts/:alertId">
               <Alerts />
             </Route>
           </Switch>

--- a/web/src/pages/Alerts.test.tsx
+++ b/web/src/pages/Alerts.test.tsx
@@ -1,9 +1,16 @@
 import { screen } from "@testing-library/react";
 import { render } from "../test-utils";
 import Alerts from "./Alerts";
+import { createMemoryHistory } from "history";
+import { Router } from "react-router";
 
 test("Alerts page smoke test", () => {
-  render(<Alerts />);
+  const history = createMemoryHistory();
+  render(
+    <Router history={history}>
+      <Alerts />
+    </Router>
+  );
   const linkElement = screen.getByText(/Active/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/web/src/pages/Alerts.tsx
+++ b/web/src/pages/Alerts.tsx
@@ -11,7 +11,8 @@ import {
   Tabs,
   Text,
 } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router";
 import { reviewAlert, useAlerts } from "../api";
 import { Alert } from "../api-types";
 import { AlertBox } from "../components/AlertBox";
@@ -43,7 +44,22 @@ const Alerts: React.FC = () => {
 
 const AlertList: React.FC = () => {
   const { data: apiData, revalidate } = useAlerts();
+  const { alertId } = useParams<{ alertId: string }>();
   const [selectedAlert, setSelectedAlert] = useState<Alert>();
+
+  // If the user visits /alerts/:alertId, show the modal for the
+  // specified alert instantly.
+  // This allows us to display a user-friendly link in IAM Zero
+  // client libraries, where a single click will take the user
+  // to the right alert in the IAM Zero console.
+  useEffect(() => {
+    if (alertId !== undefined && apiData !== undefined) {
+      const alertToSelect = apiData.find((a) => a.id === alertId);
+      if (alertToSelect !== undefined) {
+        setSelectedAlert(alertToSelect);
+      }
+    }
+  }, [alertId, apiData]);
 
   const onClose = () => setSelectedAlert(undefined);
 


### PR DESCRIPTION
Add routing to the frontend to support URLs for each captured alert
(e.g. http://localhost:9090/alerts/b49a9bc9-ce8e-4a55-ae99-362926c6034a)

Return IDs of alerts to the client when captured

Will help to address https://github.com/common-fate/iamzero-python/issues/3