### PR TITLE
Remove terraform binary from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,3 @@
-FROM debian:buster-slim as terraform_installer
-
-################################
-# Install Terraform
-################################
-WORKDIR /app
-
-# Install dependencies needed to download and verify Terraform
-RUN  apt-get update \
-  && apt-get install -y wget gnupg unzip \
-  && rm -rf /var/lib/apt/lists/*
-
-# Download terraform for linux
-RUN wget https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip
-RUN wget https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_SHA256SUMS
-RUN wget https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_SHA256SUMS.sig
-
-COPY docker/hashicorp.asc ./
-
-# Verify the signature file is untampered.
-RUN gpg --import hashicorp.asc
-
-RUN gpg --verify terraform_0.14.11_SHA256SUMS.sig terraform_0.14.11_SHA256SUMS
-
-# Verify the SHASUM matches the archive.
-RUN sha256sum --ignore-missing -c terraform_0.14.11_SHA256SUMS 
-
-# Unzip
-RUN unzip terraform_0.14.11_linux_amd64.zip
-
 ################################################
 # Build the frontend
 ################################################
@@ -68,9 +38,6 @@ RUN go build -ldflags "-X commands.version=$VERSION" -o bin/iamzero-all-in-one c
 FROM alpine:3.13.5
 
 WORKDIR /app
-
-# add the terraform binary
-COPY --from=terraform_installer /app/terraform /usr/local/bin/terraform
 
 COPY --from=server_builder /app/bin/iamzero-all-in-one /app/iamzero-all-in-one
 


### PR DESCRIPTION
Our Terraform applier no longer requires the binary present so we can reduce the size of the resulting dockerfile.