### PR TITLE
Store events in Postgres

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -95,28 +95,25 @@ func (c *AllInOneCommand) Exec(ctx context.Context, _ []string) error {
 	if err != nil {
 		return err
 	}
-	// TODO: shift these to be configurable factories, similar to TokenStoreFactory
-	actionStorage := storage.NewInMemoryActionStorage()
-	policyStorage := storage.NewInMemoryFindingStorage()
+
+	storage := storage.BuildInMemoryStorage()
 
 	if err := c.Collector.Start(ctx, &collectorApp.CollectorOptions{
-		Logger:         log,
-		Tracer:         tracer,
-		TokenStore:     store,
-		ActionStorage:  actionStorage,
-		FindingStorage: policyStorage,
-		Auditor:        c.Auditor,
+		Logger:     log,
+		Tracer:     tracer,
+		TokenStore: store,
+		Storage:    storage,
+		Auditor:    c.Auditor,
 	}); err != nil {
 		return err
 	}
 
 	if err := c.Console.Start(&consoleApp.ConsoleOptions{
-		Logger:         log,
-		Tracer:         tracer,
-		TokenStore:     store,
-		ActionStorage:  actionStorage,
-		FindingStorage: policyStorage,
-		Auditor:        c.Auditor,
+		Logger:     log,
+		Tracer:     tracer,
+		TokenStore: store,
+		Storage:    storage,
+		Auditor:    c.Auditor,
 	}); err != nil {
 		return err
 	}

--- a/cmd/cli/commands/local.go
+++ b/cmd/cli/commands/local.go
@@ -181,29 +181,26 @@ func (c *LocalCommand) Exec(ctx context.Context, _ []string) error {
 		return errors.Wrap(err, "error opening local database, ensure that you are not running 'iamzero local'")
 	}
 
-	actionStorage := storage.NewBoltActionStorage(db)
-	findingStorage := storage.NewBoltFindingStorage(db)
+	storage := storage.BuildBoltStorage(db)
 
 	c.Auditor.Setup(log)
 
 	if err := c.Collector.Start(ctx, &collectorApp.CollectorOptions{
-		Logger:         log,
-		Tracer:         tracer,
-		TokenStore:     tokenStore,
-		ActionStorage:  actionStorage,
-		FindingStorage: findingStorage,
-		Auditor:        c.Auditor,
+		Logger:     log,
+		Tracer:     tracer,
+		TokenStore: tokenStore,
+		Storage:    storage,
+		Auditor:    c.Auditor,
 	}); err != nil {
 		return err
 	}
 
 	if err := c.Console.Start(&consoleApp.ConsoleOptions{
-		Logger:         log,
-		Tracer:         tracer,
-		TokenStore:     tokenStore,
-		ActionStorage:  actionStorage,
-		FindingStorage: findingStorage,
-		Auditor:        c.Auditor,
+		Logger:     log,
+		Tracer:     tracer,
+		TokenStore: tokenStore,
+		Storage:    storage,
+		Auditor:    c.Auditor,
 	}); err != nil {
 		return err
 	}

--- a/cmd/cli/commands/scan.go
+++ b/cmd/cli/commands/scan.go
@@ -101,18 +101,16 @@ func (c *ScanCommand) Exec(ctx context.Context, args []string) error {
 		return errors.Wrap(err, "error opening local database, ensure that you are not running 'iamzero local'")
 	}
 
-	actionStorage := storage.NewBoltActionStorage(db)
-	findingStorage := storage.NewBoltFindingStorage(db)
+	storage := storage.BuildBoltStorage(db)
 
 	c.Auditor.Setup(log)
 
 	fmt.Printf("Querying CloudTrail logs for %s\n", c.roleName)
 
 	detective := events.NewDetective(events.DetectiveOpts{
-		Log:            log,
-		Auditor:        c.Auditor,
-		ActionStorage:  actionStorage,
-		FindingStorage: findingStorage,
+		Log:     log,
+		Auditor: c.Auditor,
+		Storage: storage,
 	})
 
 	a := cloudtrail.NewCloudTrailAuditor(&cloudtrail.CloudTrailAuditorParams{

--- a/cmd/collector/app/collector.go
+++ b/cmd/collector/app/collector.go
@@ -14,13 +14,12 @@ import (
 )
 
 type Collector struct {
-	log            *zap.SugaredLogger
-	tracer         trace.Tracer
-	tokenStore     tokens.TokenStorer
-	demo           bool
-	actionStorage  storage.ActionStorage
-	findingStorage storage.FindingStorage
-	auditor        *audit.Auditor
+	log        *zap.SugaredLogger
+	tracer     trace.Tracer
+	tokenStore tokens.TokenStorer
+	demo       bool
+	storage    *storage.Storage
+	auditor    *audit.Auditor
 
 	// whether to enable the AWS CDK resource integration
 	CDK                   bool
@@ -41,12 +40,11 @@ func New() *Collector {
 }
 
 type CollectorOptions struct {
-	Logger         *zap.SugaredLogger
-	Tracer         trace.Tracer
-	Auditor        *audit.Auditor
-	TokenStore     tokens.TokenStorer
-	ActionStorage  storage.ActionStorage
-	FindingStorage storage.FindingStorage
+	Logger     *zap.SugaredLogger
+	Tracer     trace.Tracer
+	Auditor    *audit.Auditor
+	TokenStore tokens.TokenStorer
+	Storage    *storage.Storage
 }
 
 func (c *Collector) AddFlags(fs *flag.FlagSet) {
@@ -64,8 +62,7 @@ func (c *Collector) Start(ctx context.Context, opts *CollectorOptions) error {
 	c.tracer = opts.Tracer
 	c.auditor = opts.Auditor
 	c.tokenStore = opts.TokenStore
-	c.actionStorage = opts.ActionStorage
-	c.findingStorage = opts.FindingStorage
+	c.storage = opts.Storage
 
 	c.auditor.Setup(c.log)
 

--- a/cmd/collector/app/routes.go
+++ b/cmd/collector/app/routes.go
@@ -66,10 +66,9 @@ func (c *Collector) HTTPCreateEventBatchHandler(w http.ResponseWriter, r *http.R
 	c.log.With("events", rec).Info("received events")
 
 	detective := events.NewDetective(events.DetectiveOpts{
-		Log:            c.log,
-		ActionStorage:  c.actionStorage,
-		FindingStorage: c.findingStorage,
-		Auditor:        c.auditor,
+		Log:     c.log,
+		Storage: c.storage,
+		Auditor: c.auditor,
 	})
 
 	var res CreateEventBatchResponse

--- a/cmd/collector/app/sqs_server.go
+++ b/cmd/collector/app/sqs_server.go
@@ -158,10 +158,9 @@ func (c *Collector) HandleSQSMessage(ctx context.Context, msg *types.Message) er
 	}
 
 	detective := events.NewDetective(events.DetectiveOpts{
-		Log:            c.log,
-		ActionStorage:  c.actionStorage,
-		FindingStorage: c.findingStorage,
-		Auditor:        c.auditor,
+		Log:     c.log,
+		Storage: c.storage,
+		Auditor: c.auditor,
 	})
 
 	_, err = detective.AnalyseEvent(e)

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -71,18 +71,15 @@ func (c *CollectorCommand) Exec(ctx context.Context, _ []string) error {
 		return err
 	}
 
-	// TODO: shift these to be configurable factories, similar to TokenStoreFactory
-	actionStorage := storage.NewInMemoryActionStorage()
-	policyStorage := storage.NewInMemoryFindingStorage()
+	storage := storage.BuildInMemoryStorage()
 
 	co := c.Collector
 
 	if err := co.Start(ctx, &app.CollectorOptions{
-		Logger:         log,
-		Tracer:         tracer,
-		TokenStore:     store,
-		ActionStorage:  actionStorage,
-		FindingStorage: policyStorage,
+		Logger:     log,
+		Tracer:     tracer,
+		TokenStore: store,
+		Storage:    storage,
 	}); err != nil {
 		return err
 	}

--- a/cmd/console/app/api/actions.go
+++ b/cmd/console/app/api/actions.go
@@ -46,7 +46,7 @@ func (h *Handlers) ListActions(w http.ResponseWriter, r *http.Request) {
 
 	actionsResponse := []ActionResponse{}
 
-	actions, err := h.ActionStorage.List()
+	actions, err := h.Storage.Action.List()
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -64,7 +64,7 @@ func (h *Handlers) GetAction(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	actionID := chi.URLParam(r, "actionID")
 
-	action, err := h.ActionStorage.Get(actionID)
+	action, err := h.Storage.Action.Get(actionID)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -95,7 +95,7 @@ func (h *Handlers) EditAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	action, err := h.ActionStorage.Get(actionID)
+	action, err := h.Storage.Action.Get(actionID)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -105,7 +105,7 @@ func (h *Handlers) EditAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	policy, err := h.FindingStorage.Get(action.FindingID)
+	policy, err := h.Storage.Finding.Get(action.FindingID)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -126,20 +126,20 @@ func (h *Handlers) EditAction(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := h.ActionStorage.Update(*action); err != nil {
+	if err := h.Storage.Action.Update(*action); err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
 	}
 
 	// return the updated Policy corresponding to this alert
-	actions, err := h.ActionStorage.ListForPolicy(policy.ID)
+	actions, err := h.Storage.Action.ListForPolicy(policy.ID)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
 	}
 
 	policy.RecalculateDocument(actions)
-	if err := h.FindingStorage.CreateOrUpdate(*policy); err != nil {
+	if err := h.Storage.Finding.CreateOrUpdate(*policy); err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
 	}

--- a/cmd/console/app/api/findings.go
+++ b/cmd/console/app/api/findings.go
@@ -24,9 +24,9 @@ func (h *Handlers) ListFindings(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "finding status must be 'active' or 'resolved'", http.StatusBadRequest)
 			return
 		}
-		findings, err = h.FindingStorage.ListForStatus(status)
+		findings, err = h.Storage.Finding.ListForStatus(status)
 	} else {
-		findings, err = h.FindingStorage.List()
+		findings, err = h.Storage.Finding.List()
 	}
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
@@ -39,7 +39,7 @@ func (h *Handlers) ListFindings(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) GetFinding(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	findingID := chi.URLParam(r, "findingID")
-	finding, err := h.FindingStorage.Get(findingID)
+	finding, err := h.Storage.Finding.Get(findingID)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -56,7 +56,7 @@ func (h *Handlers) GetFinding(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) ListActionsForFinding(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	findingID := chi.URLParam(r, "findingID")
-	alerts, err := h.ActionStorage.ListForPolicy(findingID)
+	alerts, err := h.Storage.Action.ListForPolicy(findingID)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -79,7 +79,7 @@ func (h *Handlers) FindFinding(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	finding, err := h.FindingStorage.FindByRole(storage.FindByRoleQuery{Role: role, Status: status})
+	finding, err := h.Storage.Finding.FindByRole(storage.FindByRoleQuery{Role: role, Status: status})
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -108,7 +108,7 @@ func (h *Handlers) SetFindingStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	finding, err := h.FindingStorage.Get(findingID)
+	finding, err := h.Storage.Finding.Get(findingID)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 		return
@@ -121,7 +121,7 @@ func (h *Handlers) SetFindingStatus(w http.ResponseWriter, r *http.Request) {
 
 	finding.Status = b.Status
 
-	err = h.FindingStorage.CreateOrUpdate(*finding)
+	err = h.Storage.Finding.CreateOrUpdate(*finding)
 	if err != nil {
 		io.RespondError(ctx, h.Log, w, err)
 	}

--- a/cmd/console/app/api/handlers.go
+++ b/cmd/console/app/api/handlers.go
@@ -9,9 +9,8 @@ import (
 
 // Handlers holds all of the REST API endpoints for the console
 type Handlers struct {
-	Log            *zap.SugaredLogger
-	TokenStore     tokens.TokenStorer
-	ActionStorage  storage.ActionStorage
-	FindingStorage storage.FindingStorage
-	Auditor        *audit.Auditor
+	Log        *zap.SugaredLogger
+	TokenStore tokens.TokenStorer
+	Storage    *storage.Storage
+	Auditor    *audit.Auditor
 }

--- a/cmd/console/app/console.go
+++ b/cmd/console/app/console.go
@@ -14,12 +14,11 @@ import (
 )
 
 type Console struct {
-	log            *zap.SugaredLogger
-	tracer         trace.Tracer
-	tokenStore     tokens.TokenStorer
-	actionStorage  storage.ActionStorage
-	findingStorage storage.FindingStorage
-	auditor        *audit.Auditor
+	log        *zap.SugaredLogger
+	tracer     trace.Tracer
+	tokenStore tokens.TokenStorer
+	storage    *storage.Storage
+	auditor    *audit.Auditor
 
 	Host string
 
@@ -32,12 +31,11 @@ func New() *Console {
 }
 
 type ConsoleOptions struct {
-	Logger         *zap.SugaredLogger
-	Tracer         trace.Tracer
-	TokenStore     tokens.TokenStorer
-	ActionStorage  storage.ActionStorage
-	FindingStorage storage.FindingStorage
-	Auditor        *audit.Auditor
+	Logger     *zap.SugaredLogger
+	Tracer     trace.Tracer
+	TokenStore tokens.TokenStorer
+	Storage    *storage.Storage
+	Auditor    *audit.Auditor
 }
 
 func (c *Console) AddFlags(fs *flag.FlagSet) {
@@ -48,8 +46,7 @@ func (c *Console) Start(opts *ConsoleOptions) error {
 	c.log = opts.Logger
 	c.tracer = opts.Tracer
 	c.tokenStore = opts.TokenStore
-	c.actionStorage = opts.ActionStorage
-	c.findingStorage = opts.FindingStorage
+	c.storage = opts.Storage
 	c.auditor = opts.Auditor
 
 	c.log.With("console-host", c.Host).Info("starting IAM Zero console")

--- a/cmd/console/app/routes.go
+++ b/cmd/console/app/routes.go
@@ -14,11 +14,10 @@ import (
 func (c *Console) GetConsoleRoutes() *chi.Mux {
 	router := chi.NewRouter()
 	handlers := api.Handlers{
-		Log:            c.log,
-		TokenStore:     c.tokenStore,
-		ActionStorage:  c.actionStorage,
-		FindingStorage: c.findingStorage,
-		Auditor:        c.auditor,
+		Log:        c.log,
+		TokenStore: c.tokenStore,
+		Storage:    c.storage,
+		Auditor:    c.auditor,
 	}
 
 	router.Route("/api/v1", func(r chi.Router) {

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -71,18 +71,15 @@ func (c *ConsoleCommand) Exec(ctx context.Context, _ []string) error {
 		return err
 	}
 
-	// TODO: shift these to be configurable factories, similar to TokenStoreFactory
-	actionStorage := storage.NewInMemoryActionStorage()
-	policyStorage := storage.NewInMemoryFindingStorage()
+	storage := storage.BuildInMemoryStorage()
 
 	console := c.Collector
 
 	if err := console.Start(&app.ConsoleOptions{
-		Logger:         log,
-		Tracer:         tracer,
-		TokenStore:     store,
-		ActionStorage:  actionStorage,
-		FindingStorage: policyStorage,
+		Logger:     log,
+		Tracer:     tracer,
+		TokenStore: store,
+		Storage:    storage,
 	}); err != nil {
 		return err
 	}

--- a/pkg/storage/event.go
+++ b/pkg/storage/event.go
@@ -1,0 +1,9 @@
+package storage
+
+import "github.com/common-fate/iamzero/pkg/recommendations"
+
+type EventStorage interface {
+	ListForFinding(findingID string) ([]recommendations.AWSEvent, error)
+	Get(id string) (*recommendations.AWSEvent, error)
+	Create(recommendations.AWSEvent) error
+}

--- a/pkg/storage/event_noop.go
+++ b/pkg/storage/event_noop.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	"github.com/common-fate/iamzero/pkg/recommendations"
+)
+
+// NoOpEventStorage meets the EventStorage interface but doesn't
+// do anything. It allows us to continue to use the `iamzero local` CLI
+// command workflows without a hard requirement that Postgres exists.
+// In this case, some detail views will just return no information
+// (when querying the events related to a specific finding), for example.
+// In future we can replace this with an alternative storage driver to be used for
+// local CLI usage.
+type NoOpEventStorage struct {
+}
+
+func (s *NoOpEventStorage) ListForFinding(findingID string) ([]recommendations.AWSEvent, error) {
+	return []recommendations.AWSEvent{}, nil
+}
+
+func (s *NoOpEventStorage) Create(e recommendations.AWSEvent) error {
+	return nil
+}
+
+func (s *NoOpEventStorage) Get(id string) (*recommendations.AWSEvent, error) {
+	return nil, nil
+}

--- a/pkg/storage/event_postgres.go
+++ b/pkg/storage/event_postgres.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"github.com/common-fate/iamzero/pkg/recommendations"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+)
+
+type PostgresEventStorage struct {
+	db *sqlx.DB
+}
+
+func NewPostgresEventStorage(db *sqlx.DB) *PostgresEventStorage {
+	return &PostgresEventStorage{db: db}
+}
+
+func (s *PostgresEventStorage) ListForFinding(findingID string) ([]recommendations.AWSEvent, error) {
+	e := []recommendations.AWSEvent{}
+
+	err := s.db.Select(&e, `SELECT events.id, identity_user as "identity.user", identity_role as "identity.role", identity_account as "identity.account", events.time, data FROM events INNER JOIN actions ON actions.event_id = events.id WHERE actions.finding_id=$1`, findingID)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "postgres list events")
+	}
+
+	return e, err
+}
+
+func (s *PostgresEventStorage) Create(e recommendations.AWSEvent) error {
+	_, err := s.db.Query("INSERT INTO events (id, time, identity_user, identity_role, identity_account, data) VALUES ($1, $2, $3, $4, $5, $6)",
+		e.ID, e.Time, e.Identity.User, e.Identity.Role, e.Identity.Account, e.Data,
+	)
+	return err
+}
+
+func (s *PostgresEventStorage) Get(id string) (*recommendations.AWSEvent, error) {
+	var e recommendations.AWSEvent
+
+	err := s.db.Get(&e, `SELECT events.id, identity_user as "identity.user", identity_role as "identity.role", identity_account as "identity.account", events.time, data FROM events WHERE id=$1`, id)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "postgres get event")
+	}
+
+	return &e, err
+}

--- a/pkg/storage/postgres_integration_tests/actions_test.go
+++ b/pkg/storage/postgres_integration_tests/actions_test.go
@@ -18,11 +18,12 @@ func mockAWSAction(findingID string) recommendations.AWSAction {
 		Event: recommendations.AWSEvent{
 			ID: uuid.NewString(),
 			Identity: recommendations.AWSIdentity{
-
 				User:    "testUser",
 				Role:    "testRole",
 				Account: "123456789012",
-			}, Data: recommendations.AWSData{}, Time: "2021-09-02T04:29:14Z"},
+			},
+			Data: recommendations.AWSData{},
+			Time: "2021-09-02T04:29:14Z"},
 		Status:             "test",
 		FindingID:          findingID,
 		Time:               time.Now(),

--- a/pkg/storage/postgres_integration_tests/events_test.go
+++ b/pkg/storage/postgres_integration_tests/events_test.go
@@ -1,0 +1,74 @@
+// +build postgres
+
+package postgresintegrationtests
+
+import (
+	"testing"
+
+	"github.com/common-fate/iamzero/pkg/recommendations"
+	"github.com/common-fate/iamzero/pkg/storage"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockEvent() recommendations.AWSEvent {
+	return recommendations.AWSEvent{
+		ID: uuid.NewString(),
+		Identity: recommendations.AWSIdentity{
+			User:    "testUser",
+			Role:    "testRole",
+			Account: "123456789012",
+		},
+		Data: recommendations.AWSData{},
+		Time: "2021-09-02T04:29:14Z",
+	}
+}
+
+func Test_GetEvent(t *testing.T) {
+	db, err := GetDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := storage.NewPostgresEventStorage(db)
+
+	_, err = s.ListForFinding(uuid.NewString())
+	assert.NoError(t, err)
+}
+
+func Test_CreateEvent(t *testing.T) {
+	db, err := GetDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := mockEvent()
+
+	s := storage.NewPostgresEventStorage(db)
+
+	err = s.Create(e)
+	assert.NoError(t, err)
+}
+
+func Test_CreateAndGetEvent(t *testing.T) {
+	db, err := GetDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := mockEvent()
+
+	s := storage.NewPostgresEventStorage(db)
+
+	err = s.Create(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := s.Get(e.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, e, *result)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"github.com/asdine/storm/v3"
+	"github.com/jmoiron/sqlx"
+)
+
+// StorageFactory builds and configures the storage
+// layer of the application
+type Storage struct {
+	Event   EventStorage
+	Finding FindingStorage
+	Action  ActionStorage
+}
+
+// BuildPostgresStorage builds the storage layer with Postgres as the driver
+func BuildPostgresStorage(db *sqlx.DB) *Storage {
+	return &Storage{
+		Event:   NewPostgresEventStorage(db),
+		Finding: NewPostgresFindingStorage(db),
+		Action:  NewPostgresActionStorage(db),
+	}
+}
+
+// BuildBoltStorage builds the storage layer with BoltDB as the driver
+func BuildBoltStorage(db *storm.DB) *Storage {
+	return &Storage{
+		Event:   &NoOpEventStorage{}, // currently unused in local workflows, so we pass the no-op.
+		Finding: NewBoltFindingStorage(db),
+		Action:  NewBoltActionStorage(db),
+	}
+}
+
+// BuildBoltStorage builds the storage layer using in-memory arrays
+func BuildInMemoryStorage() *Storage {
+	return &Storage{
+		Event:   &NoOpEventStorage{}, // currently unused in local workflows, so we pass the no-op.
+		Finding: NewInMemoryFindingStorage(),
+		Action:  NewInMemoryActionStorage(),
+	}
+}


### PR DESCRIPTION
Also reorganises storage objects into a single `Storage` struct.

This means we use h.Storage.Findings rather than h.findingsStorage and will mean less boilerplate config and injection of storage when we add new metadata entities to be stored.